### PR TITLE
Add antenna noise report in radotap. Disable debug by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ EXTRA_CFLAGS += -DCONFIG_RTW_ANDROID=$(CONFIG_RTW_ANDROID)
 endif
 
 ########################## Debug ###########################
-CONFIG_RTW_DEBUG = y
+CONFIG_RTW_DEBUG = n
 # default log level is _DRV_INFO_ = 4,
 # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
 CONFIG_RTW_LOG_LEVEL = 4

--- a/core/monitor/rtw_radiotap.c
+++ b/core/monitor/rtw_radiotap.c
@@ -173,7 +173,7 @@ static inline void _rtw_radiotap_fill_flags(struct rx_pkt_attrib *a, u8 *flags)
 
 sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 {
-#define RTAP_HDR_MAX 64
+#define RTAP_HDR_MAX 256
 
 	sint ret = _SUCCESS;
 	struct moinfo *moif = (struct moinfo *)&a->moif;
@@ -208,13 +208,14 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 
 	/* each antenna information */
 	rx_cnt = rf_type_to_rf_rx_cnt(pHalData->rf_type);
-#if 0
+#if 1
 	if (rx_cnt > 1) {
 		rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE) |
 		BIT(IEEE80211_RADIOTAP_EXT);
 
 		for (i = 1; i < rx_cnt; i++) {
 			tmp_32bit = (BIT(IEEE80211_RADIOTAP_DBM_ANTSIGNAL) |
+                                     BIT(IEEE80211_RADIOTAP_DBM_ANTNOISE) |
 				     BIT(IEEE80211_RADIOTAP_LOCK_QUALITY) |
 				     BIT(IEEE80211_RADIOTAP_ANTENNA) |
 				     BIT(IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE) |
@@ -224,6 +225,7 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 		}
 
 		tmp_32bit = (BIT(IEEE80211_RADIOTAP_DBM_ANTSIGNAL) |
+                             BIT(IEEE80211_RADIOTAP_DBM_ANTNOISE) |
 			     BIT(IEEE80211_RADIOTAP_LOCK_QUALITY) |
 			     BIT(IEEE80211_RADIOTAP_ANTENNA));
 		_rtw_memcpy(&hdr_buf[rt_len], &tmp_32bit, 4);
@@ -569,12 +571,16 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 	}
 
 	/* each antenna information */
-#if 0
+#if 1
 	if (rx_cnt > 1) {
 		for (i = 0; i <= rx_cnt; i++) {
 			/* dBm Antenna Signal */
-			hdr_buf[rt_len] = a->phy_info.rx_mimo_signal_strength[i];
+			hdr_buf[rt_len] = a->phy_info.rx_pwr[i];
 			rt_len += 1;
+
+                        /*  IEEE80211_RADIOTAP_DBM_ANTNOISE */
+                        hdr_buf[rt_len] = a->phy_info.rx_pwr[i] - a->phy_info.rx_snr[i];
+                        rt_len += 1;
 
 			/* Signal Quality */
 			if (!IS_ALIGNED(rt_len, 2))


### PR DESCRIPTION
Hi,
I've add two changes:
1. Disable debug by default. It add a lot of unnecessary messages for normal user
2. Add per-antenna stats and antenna noise reporting. This is used in wfb_rx