### PR TITLE
Fix error with c90 standard

### DIFF
--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -6094,8 +6094,6 @@ static ssize_t proc_set_single_tone(struct file *file, const char __user *buffer
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
 	struct dm_struct *dm;
 	dm = adapter_to_phydm(padapter);
-	
-
 
 	if (!padapter)
 		return -EFAULT;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -6006,7 +6006,7 @@ static ssize_t proc_set_dis_cca(struct file *file, const char __user *buffer, si
 {
 	char tmp[32];
 	u32 en;
-	
+
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
@@ -6086,14 +6086,16 @@ static int proc_get_single_tone(struct seq_file *m, void *v)
 
 static ssize_t proc_set_single_tone(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
+	char tmp[32];
+	u32 en, rf_path;
+
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
 	struct dm_struct *dm;
 	dm = adapter_to_phydm(padapter);
 	
-	char tmp[32];
-	u32 en, rf_path;
+
 
 	if (!padapter)
 		return -EFAULT;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -6004,15 +6004,15 @@ static int proc_get_dis_cca(struct seq_file *m, void *v)
 
 static ssize_t proc_set_dis_cca(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
+	char tmp[32];
+	u32 en;
+	
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
 	struct dm_struct *dm;
 	dm = adapter_to_phydm(padapter);
 	
-	char tmp[32];
-	u32 en;
-
 	if (!padapter)
 		return -EFAULT;
 		


### PR DESCRIPTION
Fix for error c90 standard:
```
77.98 /rv1126_rv1109_v2.2.0_20210825/buildroot/dl/rtl8812eu/os_dep/linux/rtw_proc.c: In function 'proc_set_dis_cca':
77.98 /rv1126_rv1109_v2.2.0_20210825/buildroot/dl/rtl8812eu/os_dep/linux/rtw_proc.c:6013:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
77.98 error, forbidden warning:rtw_proc.c:6013
77.98   char tmp[32];
77.98   ^~~~
77.98 /rv1126_rv1109_v2.2.0_20210825/buildroot/dl/rtl8812eu/os_dep/linux/rtw_proc.c: In function 'proc_set_single_tone':
77.98 /rv1126_rv1109_v2.2.0_20210825/buildroot/dl/rtl8812eu/os_dep/linux/rtw_proc.c:6095:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
77.98 error, forbidden warning:rtw_proc.c:6095
77.98   char tmp[32];
77.98   ^~~~
77.99 make[2]: *** [scripts/Makefile.build:334: /rv1126_rv1109_v2.2.0_20210825/buildroot/dl/rtl8812eu/os_dep/linux/rtw_proc.o] Error 1
77.99 make[2]: *** Deleting file '/rv1126_rv1109_v2.2.0_20210825/buildroot/dl/rtl8812eu/os_dep/linux/rtw_proc.o'
77.99 make[1]: Leaving directory '/rv1126_rv1109_v2.2.0_20210825/kernel'
77.99 make[1]: *** [Makefile:1641: _module_/rv1126_rv1109_v2.2.0_20210825/buildroot/dl/rtl8812eu] Error 2
77.99 make: *** [Makefile:2601: modules] Error 2
------

 2 warnings found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG ${BUILDER_IMAGE} results in empty or invalid base image name (line 2)
 - WorkdirRelativePath: Relative workdir "kernel" can have unexpected results if the base image changes (line 4)
Dockerfile.2-kernel:26
--------------------
  25 |     # драйвер для rtl88x2eu
  26 | &gt;&gt;&gt; RUN cd buildroot/dl &amp;&amp; \
  27 | &gt;&gt;&gt;     git clone https://github.com/svpcom/rtl8812eu.git &amp;&amp; \
  28 | &gt;&gt;&gt;     cd rtl8812eu &amp;&amp; \
  29 | &gt;&gt;&gt;     make \
  30 | &gt;&gt;&gt;         KSRC=/rv1126_rv1109_v2.2.0_20210825/kernel \
  31 | &gt;&gt;&gt;         ARCH=arm \
  32 | &gt;&gt;&gt;         CROSS_COMPILE=/rv1126_rv1109_v2.2.0_20210825/prebuilts/gcc/linux-x86/arm/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
  33 |     
--------------------
ERROR: failed to solve: process "/bin/bash -c cd buildroot/dl &amp;&amp;     git clone https://github.com/svpcom/rtl8812eu.git &amp;&amp;     cd rtl8812eu &amp;&amp;     make         KSRC=/rv1126_rv1109_v2.2.0_20210825/kernel         ARCH=arm         CROSS_COMPILE=/rv1126_rv1109_v2.2.0_20210825/prebuilts/gcc/linux-x86/arm/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf/bin/arm-linux-gnueabihf-" did not complete successfully: exit code: 2
make: *** [Makefile:22: kernel] Error 1
```