### PR TITLE
Fix VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver not import error

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -25,6 +25,7 @@ MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Realtek Wireless Lan Driver");
 MODULE_AUTHOR("Realtek Semiconductor Corp.");
 MODULE_VERSION(DRIVERVERSION);
+MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0))
 MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
 #endif


### PR DESCRIPTION
Got `ERROR: modpost: module 8812eu uses symbol kernel_read from namespace VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver, but does not import it. ` since this [commit](https://github.com/libc0607/rtl88x2eu-20230815/commit/6418c2430185a4eda9f8b14f1a5f5846d50942a5)