### PR TITLE
Add lightweight proc entries for per-chain RSSI/SNR and public-queue free pages

### DIFF
--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -3699,6 +3699,56 @@ int proc_get_trx_info_debug(struct seq_file *m, void *v)
 	return 0;
 }
 
+int proc_get_rssi_a(struct seq_file *m, void *v)
+{
+	struct net_device *dev = m->private;
+	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
+	struct dm_struct *dm = adapter_to_phydm(padapter);
+
+	RTW_PRINT_SEL(m, "%d\n", dm->rssi_a);
+	return 0;
+}
+
+int proc_get_rssi_b(struct seq_file *m, void *v)
+{
+	struct net_device *dev = m->private;
+	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
+	struct dm_struct *dm = adapter_to_phydm(padapter);
+
+	RTW_PRINT_SEL(m, "%d\n", dm->rssi_b);
+	return 0;
+}
+
+int proc_get_snr_a(struct seq_file *m, void *v)
+{
+	struct net_device *dev = m->private;
+	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
+
+	RTW_PRINT_SEL(m, "%d\n", padapter->recvpriv.ofdm_snr_latest[RF_PATH_A]);
+	return 0;
+}
+
+int proc_get_snr_b(struct seq_file *m, void *v)
+{
+	struct net_device *dev = m->private;
+	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
+
+	RTW_PRINT_SEL(m, "%d\n", padapter->recvpriv.ofdm_snr_latest[RF_PATH_B]);
+	return 0;
+}
+
+int proc_get_pubq_free_page(struct seq_file *m, void *v)
+{
+	struct net_device *dev = m->private;
+	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
+	u32 reg, pubq;
+
+	reg = rtw_read32(padapter, 0x0240);
+	pubq = (reg >> 16) & 0x0FFF;
+	RTW_PRINT_SEL(m, "%u\n", pubq);
+	return 0;
+}
+
 int proc_get_rx_signal(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -103,6 +103,7 @@ sint _rtw_init_recv_priv(struct recv_priv *precvpriv, _adapter *padapter)
 #else
 	precvpriv->store_law_data_flag = 0;
 #endif
+	_rtw_memset(precvpriv->ofdm_snr_latest, 0, sizeof(precvpriv->ofdm_snr_latest));
 
 	rtw_os_recv_resource_init(precvpriv, padapter);
 
@@ -5039,4 +5040,3 @@ void dump_rx_bh_tk(void *sel, struct recv_priv *recv)
 	);
 }
 #endif /* DBG_RX_BH_TRACKING */
-

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -15800,10 +15800,16 @@ void rtw_store_phy_info(_adapter *padapter, union recv_frame *prframe)
 	dframe_type = GetFrameType(ptr);
 	/*RTW_INFO("=>%s\n", __FUNCTION__);*/
 
+	isCCKrate = (pattrib->data_rate <= DESC_RATE11M) ? TRUE : FALSE;
+	if (!isCCKrate) {
+		for (rf_path = 0; rf_path < hal_spec->rf_reg_path_num; rf_path++) {
+			if (!(GET_HAL_RX_PATH_BMP(padapter) & BIT(rf_path)))
+				continue;
+			precvpriv->ofdm_snr_latest[rf_path] = p_phy_info->rx_snr[rf_path];
+		}
+	}
 
 	if (precvpriv->store_law_data_flag) {
-		isCCKrate = (pattrib->data_rate <= DESC_RATE11M) ? TRUE : FALSE;
-
 		psample_pkt_rssi->pwdball = p_phy_info->rx_pwdb_all;
 		psample_pkt_rssi->pwr_all = p_phy_info->recv_signal_power;
 

--- a/include/rtw_debug.h
+++ b/include/rtw_debug.h
@@ -410,6 +410,11 @@ int proc_get_huawei_trx_info(struct seq_file *m, void *v);
 
 int proc_get_rx_signal(struct seq_file *m, void *v);
 ssize_t proc_set_rx_signal(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data);
+int proc_get_rssi_a(struct seq_file *m, void *v);
+int proc_get_rssi_b(struct seq_file *m, void *v);
+int proc_get_snr_a(struct seq_file *m, void *v);
+int proc_get_snr_b(struct seq_file *m, void *v);
+int proc_get_pubq_free_page(struct seq_file *m, void *v);
 int proc_get_hw_status(struct seq_file *m, void *v);
 ssize_t proc_set_hw_status(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data);
 int proc_get_mac_rptbuf(struct seq_file *m, void *v);

--- a/include/rtw_recv.h
+++ b/include/rtw_recv.h
@@ -523,6 +523,7 @@ struct recv_priv {
 	u8 signal_qual;
 	s8 rssi;	/* translate_percentage_to_dbm(ptarget_wlan->network.PhyInfo.SignalStrength); */
 	struct rx_raw_rssi raw_rssi_info;
+	s8 ofdm_snr_latest[4];
 	/* s8 rxpwdb;	 */
 	/* int RxSNRdB[2]; */
 	/* s8 RxRssi[2]; */

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -6422,6 +6422,11 @@ const struct rtw_proc_hdl adapter_proc_hdls[] = {
 #endif
 
 	RTW_PROC_HDL_SSEQ("rx_signal", proc_get_rx_signal, proc_set_rx_signal),
+	RTW_PROC_HDL_SSEQ("rssi_a", proc_get_rssi_a, NULL),
+	RTW_PROC_HDL_SSEQ("rssi_b", proc_get_rssi_b, NULL),
+	RTW_PROC_HDL_SSEQ("snr_a", proc_get_snr_a, NULL),
+	RTW_PROC_HDL_SSEQ("snr_b", proc_get_snr_b, NULL),
+	RTW_PROC_HDL_SSEQ("pubq_free_page", proc_get_pubq_free_page, NULL),
 	RTW_PROC_HDL_SSEQ("rx_chk_limit", proc_get_rx_chk_limit, proc_set_rx_chk_limit),
 	RTW_PROC_HDL_SSEQ("hw_info", proc_get_hw_status, proc_set_hw_status),
 	RTW_PROC_HDL_SSEQ("mac_rptbuf", proc_get_mac_rptbuf, NULL),


### PR DESCRIPTION

This PR includes lightweight procfs nodes for high-rate telemetry sampling
Tested only in AP mode
All files print a single integer to keep userland parsing and CPU overhead low.

Procfs nodes (per interface):

- /proc/net/rtl88x2eu/<ifname>/rssi_a
  - Current per-path RSSI from ODM (path A), integer.
- /proc/net/rtl88x2eu/<ifname>/rssi_b
  - Current per-path RSSI from ODM (path B), integer.
- /proc/net/rtl88x2eu/<ifname>/snr_a
  - Latest per-path OFDM SNR sample (dB, path A), integer.
- /proc/net/rtl88x2eu/<ifname>/snr_b
  - Latest per-path OFDM SNR sample (dB, path B), integer.
- /proc/net/rtl88x2eu/<ifname>/pubq_free_page
  - Available public TX FIFO pages, integer.

Sampling behavior:

- SNR sampling is always enabled and updates on every OFDM packet.
- SNR values are cached in recvpriv->ofdm_snr_latest[RF_PATH_*] so reads are fast.
- RSSI values use dm_struct::rssi_a/rssi_b (ODM per-path RSSI).
- pubq_free_page reads REG_FIFOPAGE_INFO_5 (0x0240), upper 12 bits.

Code touch points:

- include/rtw_recv.h
  - Added recvpriv->ofdm_snr_latest[4].
- core/rtw_recv.c
  - Initialized ofdm_snr_latest to 0 on recvpriv init.
- hal/hal_com.c
  - Update ofdm_snr_latest on every OFDM packet (independent of store_law_data_flag).
- core/rtw_debug.c
  - Added proc handlers: proc_get_rssi_a/b, proc_get_snr_a/b, proc_get_pubq_free_page.
- include/rtw_debug.h
  - Added prototypes for new proc handlers.
- os_dep/linux/rtw_proc.c
  - Registered proc nodes under adapter_proc_hdls.

Example usage:

watch -n0.1 cat /proc/net/rtl88x2eu/wlan0/rssi_a
