### PR TITLE
Enable driver returning NETDEV_TX_BUSY when TxBuffer is full

### DIFF
--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -17,6 +17,14 @@
 #include <drv_types.h>
 #include <hal_data.h>
 
+#include <linux/module.h>
+#include <linux/moduleparam.h>
+
+
+static int MaxTxBufLen = 0; /* default disabled */
+module_param(MaxTxBufLen, int, 0444);
+MODULE_PARM_DESC(MaxTxBufLen, "Max TX buffer size taken before returning NETDEV_TX_BUSY");
+
 static u8 P802_1H_OUI[P80211_OUI_LEN] = { 0x00, 0x00, 0xf8 };
 static u8 RFC1042_OUI[P80211_OUI_LEN] = { 0x00, 0x00, 0x00 };
 
@@ -75,6 +83,12 @@ s32	_rtw_init_xmit_priv(struct xmit_priv *pxmitpriv, _adapter *padapter)
 	struct xmit_buf *pxmitbuf;
 	struct xmit_frame *pxframe;
 	sint	res = _SUCCESS;
+
+
+	pr_info("8812eu:  ----  _rtw_init_xmit_priv ------------");
+	pr_err("8812eu: _rtw_init_xmit_priv");
+	if (MaxTxBufLen>0)
+		pr_err("8812eu: Use max %d of %d Tx buffer slots before returning NETDEV_TX_BUSY ", MaxTxBufLen , NR_XMIT_EXTBUFF);
 
 
 	/* We don't need to memset padapter->XXX to zero, because adapter is allocated by rtw_zvmalloc(). */
@@ -4946,6 +4960,11 @@ s32 rtw_monitor_xmit_entry(struct sk_buff *skb, struct net_device *ndev)
 	rtap_len = ieee80211_get_radiotap_len(skb->data);
 	if (unlikely(skb->len < rtap_len))
 		goto fail;
+
+	if (MaxTxBufLen>0 && 
+		 pxmitpriv->free_xframe_ext_cnt <= NR_XMIT_EXTBUFF - MaxTxBufLen ||  // check tx queue if is about to get full
+            pxmitpriv->free_xmit_extbuf_cnt <= NR_XMIT_EXTBUFF - MaxTxBufLen )  // check if we can allocate more buffers before even trying to do anything       
+               return NETDEV_TX_BUSY; 
 
 	pmgntframe = monitor_alloc_mgtxmitframe(pxmitpriv);
 	if (unlikely(pmgntframe == NULL)) {

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -85,8 +85,6 @@ s32	_rtw_init_xmit_priv(struct xmit_priv *pxmitpriv, _adapter *padapter)
 	sint	res = _SUCCESS;
 
 
-	pr_info("8812eu:  ----  _rtw_init_xmit_priv ------------");
-	pr_err("8812eu: _rtw_init_xmit_priv");
 	if (MaxTxBufLen>0)
 		pr_err("8812eu: Use max %d of %d Tx buffer slots before returning NETDEV_TX_BUSY ", MaxTxBufLen , NR_XMIT_EXTBUFF);
 

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -86,7 +86,7 @@ s32	_rtw_init_xmit_priv(struct xmit_priv *pxmitpriv, _adapter *padapter)
 
 
 	if (MaxTxBufLen>0)
-		pr_err("8812eu: Use max %d of %d Tx buffer slots before returning NETDEV_TX_BUSY ", MaxTxBufLen , NR_XMIT_EXTBUFF);
+		pr_info("8812eu: Use max %d of %d Tx buffer slots before returning NETDEV_TX_BUSY ", MaxTxBufLen , NR_XMIT_EXTBUFF);
 
 
 	/* We don't need to memset padapter->XXX to zero, because adapter is allocated by rtw_zvmalloc(). */
@@ -4960,8 +4960,8 @@ s32 rtw_monitor_xmit_entry(struct sk_buff *skb, struct net_device *ndev)
 		goto fail;
 
 	if (MaxTxBufLen>0 && 
-		 pxmitpriv->free_xframe_ext_cnt <= NR_XMIT_EXTBUFF - MaxTxBufLen ||  // check tx queue if is about to get full
-            pxmitpriv->free_xmit_extbuf_cnt <= NR_XMIT_EXTBUFF - MaxTxBufLen )  // check if we can allocate more buffers before even trying to do anything       
+		 ((pxmitpriv->free_xframe_ext_cnt <= NR_XMIT_EXTBUFF - MaxTxBufLen) ||  // check tx queue if is about to get full
+            (pxmitpriv->free_xmit_extbuf_cnt <= NR_XMIT_EXTBUFF - MaxTxBufLen)))  // check if we can allocate more buffers before even trying to do anything       
                return NETDEV_TX_BUSY; 
 
 	pmgntframe = monitor_alloc_mgtxmitframe(pxmitpriv);

--- a/os_dep/linux/xmit_linux.c
+++ b/os_dep/linux/xmit_linux.c
@@ -559,7 +559,7 @@ int rtw_xmit_entry(_pkt *pkt, _nic_hdl pnetdev)
 #endif
 		if (check_fwstate(pmlmepriv, WIFI_MONITOR_STATE) == _TRUE) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-			rtw_monitor_xmit_entry((struct sk_buff *)pkt, pnetdev);
+			ret = rtw_monitor_xmit_entry((struct sk_buff *)pkt, pnetdev);
 #endif
 		}
 		else {


### PR DESCRIPTION
This patch updates the driver to return NETDEV_TX_BUSY when the transmit (Tx) buffer is depleted during packet injection.

The module parameter MaxTxBufLen allows defining a smaller threshold for triggering this condition. The default buffer size is 64 frames, as defined by NR_XMIT_EXTBUFF. Waiting for the entire buffer to fill before notifying the sender can increase video latency, so this patch improves responsiveness under high load.
By default, MaxTxBufLen is 0, so this feature is disabled.
Setting low values for MaxTxBufLen (1–20) increases the pressure on the sender to reduce its bitrate.